### PR TITLE
Fix mix project stack

### DIFF
--- a/src/exerl_elixir_compiler.erl
+++ b/src/exerl_elixir_compiler.erl
@@ -21,7 +21,8 @@ context(AppInfo) ->
         exerl_util:ensure_started(mix),
 
         AppName = binary_to_atom(rebar_app_info:name(AppInfo)),
-        ?ProjectStack:push(
+        IsMix = mix =:= rebar_app_info:project_type(AppInfo),
+        IsMix andalso ?ProjectStack:push(
             AppName,
             [{app, AppName}],
             <<"nofile">>


### PR DESCRIPTION
The `exerl_elixir_compiler` was prepended to rebar compilers. So the `exerl_elixir_compiler:context/1` callback will receive rebar3 plugins or other non-mix apps.

If a non-mix project was pushed to it, the compilation fails:

```
===> Uncaught error in rebar_core. Run with DIAGNOSTIC=1 to see stacktrace or consult rebar3.crashdump
===> Uncaught error: #{'__exception__' => true,
                              '__struct__' => 'Elixir.RuntimeError',
                              message =>
                                  <<"cannot retrieve dependencies information because dependencies were not loaded. Please invoke one of \"deps.loadpaths\", \"loadpaths\", or \"compile\" Mix task">>}
===> Stack trace to the error location:
[{'Elixir.Mix.Dep',load_and_cache,5,
                   [{file,"lib/mix/dep.ex"},
                    {line,128},
                    {error_info,#{module => 'Elixir.Exception'}}]},
 {'Elixir.Mix.Dep',load_and_cache,0,[{file,"lib/mix/dep.ex"},{line,114}]},
 {'Elixir.Mix.Tasks.Deps.Loadpaths',run,1,
                                    [{file,"lib/mix/tasks/deps.loadpaths.ex"},
                                     {line,32}]},
 {'Elixir.Mix.Task','-run_task/5-fun-3-',3,
                    [{file,"lib/mix/task.ex"},{line,478}]},
 {timer,tc,1,[{file,"timer.erl"},{line,235}]},
 {'Elixir.Mix.Task',with_debug,4,[{file,"lib/mix/task.ex"},{line,502}]},
 {'Elixir.Mix.Tasks.Loadpaths',run,1,
                               [{file,"lib/mix/tasks/loadpaths.ex"},
                                {line,37}]},
 {'Elixir.Mix.Task','-run_task/5-fun-3-',3,
                    [{file,"lib/mix/task.ex"},{line,478}]}]
===> When submitting a bug report, please include the output of `rebar3 report "your command"`
```


To fix this, push the project info to the mix project stack only when it is a mix project.